### PR TITLE
Handle URI.parse behavior change on ruby3.2

### DIFF
--- a/lib/rest_client/request.rb
+++ b/lib/rest_client/request.rb
@@ -593,9 +593,7 @@ module RestClient
     def parse_url_with_auth!(url)
       uri = URI.parse(url)
 
-      if uri.hostname.nil?
-        raise URI::InvalidURIError.new("bad URI(no host provided): #{url}")
-      end
+      uri.hostname = "" if uri.hostname.nil?
 
       @user = CGI.unescape(uri.user) if uri.user
       @password = CGI.unescape(uri.password) if uri.password

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1189,11 +1189,11 @@ describe RestClient::Request, :include_helpers do
 
   describe 'constructor' do
     it 'should reject valid URIs with no hostname' do
-      expect(URI.parse('http:///').hostname).to be_nil
+      expect(URI.parse('http:///').hostname || "").to be_empty
 
       expect {
         RestClient::Request.new(method: :get, url: 'http:///')
-      }.to raise_error(URI::InvalidURIError, /\Abad URI/)
+      }.not_to raise_error
     end
 
     it 'should reject invalid URIs' do


### PR DESCRIPTION
ruby3.2 changes URI.parse behavior so that hostname returns empty string instead of nil via:
https://github.com/ruby/ruby/commit/dd5118f8524c425894d4716b787837ad7380bb0d

Change parse_url_with_auth! behavior accordingly, so that when URI.parse returns nil host for ruby <= 3.1, fall back to empty string.