### PR TITLE
Handle URI.parse behavior change on Ruby 3.2

### DIFF
--- a/lib/rest_client/request.rb
+++ b/lib/rest_client/request.rb
@@ -593,7 +593,7 @@ module RestClient
     def parse_url_with_auth!(url)
       uri = URI.parse(url)
 
-      if uri.hostname.nil?
+      if uri.hostname.nil? || uri.hostname.empty?
         raise URI::InvalidURIError.new("bad URI(no host provided): #{url}")
       end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -1189,7 +1189,11 @@ describe RestClient::Request, :include_helpers do
 
   describe 'constructor' do
     it 'should reject valid URIs with no hostname' do
-      expect(URI.parse('http:///').hostname).to be_nil
+      if RUBY_VERSION >= "3.2.0"
+        expect(URI.parse('http:///').hostname).to be_empty
+      else
+        expect(URI.parse('http:///').hostname).to be_nil
+      end
 
       expect {
         RestClient::Request.new(method: :get, url: 'http:///')


### PR DESCRIPTION
Ruby 3.2 changes URI.parse behavior so that hostname returns empty string instead of nil via : https://github.com/ruby/ruby/commit/dd5118f8524c425894d4716b787837ad7380bb0d

Replace https://github.com/jbox-web/rest-client/pull/1